### PR TITLE
Update smartbanner.js

### DIFF
--- a/src/smartbanner.js
+++ b/src/smartbanner.js
@@ -184,7 +184,7 @@ export default class SmartBanner {
   }
 
   get apiEnabled() {
-    return this.options.api === 'true';
+    return this.options.api === 'true' || this.options.api === 'yes';
   }
 
   get userAgentExcluded() {


### PR DESCRIPTION
Alternative condition for enable smartbanner API use.

Some frameworks disallow use meta with content "true" string, for Example Nuxt.